### PR TITLE
Add pkg-config as build dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,6 +11,8 @@
   <depend>muparser</depend>
   <depend>std_msgs</depend>
 
+  <build_depend>pkg-config</build_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 


### PR DESCRIPTION
Fixes build error on official buildfarm
https://build.ros2.org/job/Hdev__parameter_expression__ubuntu_jammy_amd64/1/